### PR TITLE
Add warp-events to dirt-age flowchart

### DIFF
--- a/flowchart/LV-Unlock.mmd
+++ b/flowchart/LV-Unlock.mmd
@@ -187,6 +187,7 @@ flowchart TD
     BH -->|Lava| BI
     BI --> BJ
     ZD --> SG_WA
+    WE_SWAMP --> SG_WA
 
     %% Styling
     classDef gate color:#000000, fill:#00C853

--- a/flowchart/LV-Unlock.mmd
+++ b/flowchart/LV-Unlock.mmd
@@ -39,7 +39,7 @@ flowchart TD
             ZC(Pech Trading)
             ZD(Silverwood + Greatwood Saplings)
         end
-        subgraph SG_PC [WARP EVENTS]
+        subgraph SG_WE [WARP EVENTS]
             WE_SWAMP(SWAMP-EVENT\ Saplings, Water)
             WE_COIN(COIN-EVENT\ Single Coin)
             WE_JUNK(JUNK-EVENT\ Cobblestone, Dirt)

--- a/flowchart/LV-Unlock.mmd
+++ b/flowchart/LV-Unlock.mmd
@@ -39,6 +39,11 @@ flowchart TD
             ZC(Pech Trading)
             ZD(Silverwood + Greatwood Saplings)
         end
+        subgraph SG_PC [WARP EVENTS]
+            WE_SWAMP(SWAMP-EVENT\ Saplings, Water)
+            WE_COIN(COIN-EVENT\ Single Coin)
+            WE_JUNK(JUNK-EVENT\ Cobblestone, Dirt)
+        end
         ZA --> ZC
         ZB --> ZC
         ZC --> ZD
@@ -190,3 +195,4 @@ flowchart TD
     class AG gate
     class BJ gate
     class ZD gate
+    class WE_SWAMP gate


### PR DESCRIPTION
Saplings can not only be obtained from villagers or pechs, but also from the swamp warp-event. I updated the flowchart to reflect that.

I did **not** re-render the mmd into svg yet. Using Mermaidchart.com yielded results that looked awkward and different from the current svg.

We can consider setting up github-actions to automatically render mmd into svg on every push. I can submit a PR for that, if you'd like.